### PR TITLE
增加谷歌广告(首页文章独立页面便于修改)

### DIFF
--- a/layout/includes/widgets/home/Adsense.pug
+++ b/layout/includes/widgets/home/Adsense.pug
@@ -1,0 +1,5 @@
+div.recent-post-item
+    div.recent-post-adsense(style="width:100%;display: flex;height: calc(25.5vw);overflow: hidden;")
+        ins(class="adsbygoogle", style="display:block; text-align:center;", data-ad-format="auto", data-full-width-responsive="true", data-ad-client="ca-pub-4015694772463475", data-ad-slot="8371555862")
+        script.
+          (adsbygoogle = window.adsbygoogle || []).push({});


### PR DESCRIPTION
如果你忍得住一半文章一半广告，可以在/layout/index.pug直接添加如下代码(顶格粘贴)
```
                include ./includes/widgets/home/Adsense.pug
```
其他三个文章后一个广告框需要大佬在/layout/index.pug页面进行开发